### PR TITLE
Die Dateien zum Datei-Handling. Die Zusätze kommen dann später

### DIFF
--- a/src/main/java/de/hhu/propra16/amigos/tdd/xml/Exercise.java
+++ b/src/main/java/de/hhu/propra16/amigos/tdd/xml/Exercise.java
@@ -1,0 +1,36 @@
+package de.hhu.propra16.amigos.tdd.xml;
+
+
+import java.util.HashMap;
+
+public class Exercise {
+    private String name;
+    private String description;
+    private HashMap<String, String> classes;
+    private HashMap<String, String> tests;
+
+
+    public Exercise(String name, String description, HashMap<String, String> classes, HashMap<String, String> tests) {
+        this.name = name;
+        this.description = description;
+        this.classes = classes;
+        this.tests = tests;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public HashMap<String, String> getClasses() {
+        return classes;
+    }
+
+    public HashMap<String, String> getTests() {
+        return tests;
+    }
+
+}

--- a/src/main/java/de/hhu/propra16/amigos/tdd/xml/Exercise.java
+++ b/src/main/java/de/hhu/propra16/amigos/tdd/xml/Exercise.java
@@ -8,10 +8,10 @@ public class Exercise {
     private String description;
     private HashMap<String, String> classes;
     private HashMap<String, String> tests;
-    private HashMap<String, Boolean> options;
+    private HashMap<String, String> options;
 
 
-    public Exercise(String name, String description, HashMap<String, String> classes, HashMap<String, String> tests, HashMap<String, Boolean> options) {
+    public Exercise(String name, String description, HashMap<String, String> classes, HashMap<String, String> tests, HashMap<String, String> options) {
         this.name = name;
         this.description = description;
         this.classes = classes;
@@ -35,7 +35,7 @@ public class Exercise {
         return tests;
     }
 
-    public HashMap<String, Boolean> getOptions() {
+    public HashMap<String, String> getOptions() {
         return options;
     }
 

--- a/src/main/java/de/hhu/propra16/amigos/tdd/xml/Exercise.java
+++ b/src/main/java/de/hhu/propra16/amigos/tdd/xml/Exercise.java
@@ -8,13 +8,15 @@ public class Exercise {
     private String description;
     private HashMap<String, String> classes;
     private HashMap<String, String> tests;
+    private HashMap<String, Boolean> options;
 
 
-    public Exercise(String name, String description, HashMap<String, String> classes, HashMap<String, String> tests) {
+    public Exercise(String name, String description, HashMap<String, String> classes, HashMap<String, String> tests, HashMap<String, Boolean> options) {
         this.name = name;
         this.description = description;
         this.classes = classes;
         this.tests = tests;
+        this.options = options;
     }
 
     public String getName() {
@@ -31,6 +33,10 @@ public class Exercise {
 
     public HashMap<String, String> getTests() {
         return tests;
+    }
+
+    public HashMap<String, Boolean> getOptions() {
+        return options;
     }
 
 }

--- a/src/main/java/de/hhu/propra16/amigos/tdd/xml/Katalog.java
+++ b/src/main/java/de/hhu/propra16/amigos/tdd/xml/Katalog.java
@@ -10,8 +10,8 @@ public class Katalog {
         exercises = new ArrayList<>();
     }
 
-    public void addExercise(String name, String description, HashMap<String, String> classes, HashMap<String, String> tests/*, ArrayList<Konfiguration> konfiguration*/) {
-        exercises.add(new Exercise(name, description, classes, tests/*, konfiguration*/));
+    public void addExercise(String name, String description, HashMap<String, String> classes, HashMap<String, String> tests, HashMap<String, Boolean> options) {
+        exercises.add(new Exercise(name, description, classes, tests, options));
     }
 
     public int size() {
@@ -32,6 +32,10 @@ public class Katalog {
 
     public HashMap<String, String> getTests(int a) {
         return exercises.get(a).getTests();
+    }
+
+    public HashMap<String, Boolean> getOptions(int a) {
+        return exercises.get(a).getOptions();
     }
 
 }

--- a/src/main/java/de/hhu/propra16/amigos/tdd/xml/Katalog.java
+++ b/src/main/java/de/hhu/propra16/amigos/tdd/xml/Katalog.java
@@ -10,7 +10,7 @@ public class Katalog {
         exercises = new ArrayList<>();
     }
 
-    public void addExercise(String name, String description, HashMap<String, String> classes, HashMap<String, String> tests, HashMap<String, Boolean> options) {
+    public void addExercise(String name, String description, HashMap<String, String> classes, HashMap<String, String> tests, HashMap<String, String> options) {
         exercises.add(new Exercise(name, description, classes, tests, options));
     }
 
@@ -34,7 +34,7 @@ public class Katalog {
         return exercises.get(a).getTests();
     }
 
-    public HashMap<String, Boolean> getOptions(int a) {
+    public HashMap<String, String> getOptions(int a) {
         return exercises.get(a).getOptions();
     }
 

--- a/src/main/java/de/hhu/propra16/amigos/tdd/xml/Katalog.java
+++ b/src/main/java/de/hhu/propra16/amigos/tdd/xml/Katalog.java
@@ -1,0 +1,37 @@
+package de.hhu.propra16.amigos.tdd.xml;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class Katalog {
+    private ArrayList<Exercise> exercises;
+
+    public Katalog() {
+        exercises = new ArrayList<>();
+    }
+
+    public void addExercise(String name, String description, HashMap<String, String> classes, HashMap<String, String> tests/*, ArrayList<Konfiguration> konfiguration*/) {
+        exercises.add(new Exercise(name, description, classes, tests/*, konfiguration*/));
+    }
+
+    public int size() {
+        return exercises.size();
+    }
+
+    public String getName(int a) {
+        return exercises.get(a).getName();
+    }
+
+    public String getDescription(int a) {
+        return exercises.get(a).getDescription();
+    }
+
+    public HashMap<String, String> getClasses(int a) {
+        return exercises.get(a).getClasses();
+    }
+
+    public HashMap<String, String> getTests(int a) {
+        return exercises.get(a).getTests();
+    }
+
+}

--- a/src/main/java/de/hhu/propra16/amigos/tdd/xml/KatalogLeser.java
+++ b/src/main/java/de/hhu/propra16/amigos/tdd/xml/KatalogLeser.java
@@ -42,9 +42,9 @@ public class KatalogLeser {
                 tests.put(aktuell.getElementsByTagName("test").item(j).getAttributes().getNamedItem("name").getTextContent().trim(), aktuell.getElementsByTagName("test").item(j).getTextContent().trim());
             }
 
-            HashMap<String, Boolean> options = new HashMap<>();
+            HashMap<String, String> options = new HashMap<>();
             for(int j = 0; j < aktuell.getElementsByTagName("option").getLength(); j++) {
-                options.put(aktuell.getElementsByTagName("option").item(j).getAttributes().getNamedItem("name").getTextContent().trim(), Boolean.parseBoolean(aktuell.getElementsByTagName("option").item(j).getAttributes().getNamedItem("value").getTextContent().trim()));
+                options.put(aktuell.getElementsByTagName("option").item(j).getAttributes().getNamedItem("name").getTextContent().trim(), aktuell.getElementsByTagName("option").item(j).getAttributes().getNamedItem("value").getTextContent().trim());
             }
 
             k.addExercise(name, description, classes, tests, options);

--- a/src/main/java/de/hhu/propra16/amigos/tdd/xml/KatalogLeser.java
+++ b/src/main/java/de/hhu/propra16/amigos/tdd/xml/KatalogLeser.java
@@ -1,0 +1,51 @@
+package de.hhu.propra16.amigos.tdd.xml;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+
+public class KatalogLeser {
+    /**
+     *  Schmeißt Exceptions, damit Fehlermeldungen an anderen Stellen im Programm
+     *  ausgegeben bzw. behandelt werden können
+     */
+
+    public static Katalog lese(File f) throws ParserConfigurationException, IOException, SAXException {
+        DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = builderFactory.newDocumentBuilder();
+        Document xmlDokument = builder.parse(f);
+
+        NodeList exercises = xmlDokument.getElementsByTagName("exercise");
+
+        Katalog k = new Katalog();
+
+        for(int i = 0; i < exercises.getLength(); i++) {
+            Element aktuell = (Element) (exercises.item(i));
+            String name = aktuell.getElementsByTagName("name").item(0).getTextContent().trim();
+            String description = aktuell.getElementsByTagName("description").item(0).getTextContent().trim();
+
+            HashMap<String, String> classes = new HashMap<>();
+            for(int j = 0; j < aktuell.getElementsByTagName("class").getLength(); j++) {
+                classes.put(aktuell.getElementsByTagName("class").item(j).getAttributes().getNamedItem("name").getTextContent().trim(), aktuell.getElementsByTagName("class").item(j).getTextContent().trim());
+            }
+
+            HashMap<String, String> tests = new HashMap<>();
+            for(int j = 0; j < aktuell.getElementsByTagName("test").getLength(); j++) {
+                tests.put(aktuell.getElementsByTagName("test").item(j).getAttributes().getNamedItem("name").getTextContent().trim(), aktuell.getElementsByTagName("test").item(j).getTextContent().trim());
+            }
+
+
+            k.addExercise(name, description, classes, tests);
+        }
+
+        return k;
+    }
+}

--- a/src/main/java/de/hhu/propra16/amigos/tdd/xml/KatalogLeser.java
+++ b/src/main/java/de/hhu/propra16/amigos/tdd/xml/KatalogLeser.java
@@ -42,8 +42,12 @@ public class KatalogLeser {
                 tests.put(aktuell.getElementsByTagName("test").item(j).getAttributes().getNamedItem("name").getTextContent().trim(), aktuell.getElementsByTagName("test").item(j).getTextContent().trim());
             }
 
+            HashMap<String, Boolean> options = new HashMap<>();
+            for(int j = 0; j < aktuell.getElementsByTagName("option").getLength(); j++) {
+                options.put(aktuell.getElementsByTagName("option").item(j).getAttributes().getNamedItem("name").getTextContent().trim(), Boolean.parseBoolean(aktuell.getElementsByTagName("option").item(j).getAttributes().getNamedItem("value").getTextContent().trim()));
+            }
 
-            k.addExercise(name, description, classes, tests);
+            k.addExercise(name, description, classes, tests, options);
         }
 
         return k;

--- a/src/main/java/de/hhu/propra16/amigos/tdd/xml/SaveProgress.java
+++ b/src/main/java/de/hhu/propra16/amigos/tdd/xml/SaveProgress.java
@@ -1,0 +1,63 @@
+package de.hhu.propra16.amigos.tdd.xml;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.File;
+
+public class SaveProgress {
+    public static void save(Katalog k, File f) throws Exception {
+        DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = builderFactory.newDocumentBuilder();
+        Document dokument = builder.newDocument();
+
+        Element exercises = dokument.createElement("exercises");
+        dokument.appendChild(exercises);
+
+        for(int i = 0; i < k.size(); i++){
+            Element exercise = dokument.createElement("exercise");
+            exercises.appendChild(exercise);
+
+            Element name = dokument.createElement("name");
+            name.appendChild(dokument.createTextNode(k.getName(i)));
+            exercise.appendChild(name);
+
+            Element description = dokument.createElement("description");
+            description.appendChild(dokument.createTextNode(k.getDescription(i)));
+            exercise.appendChild(description);
+
+            Element classes = dokument.createElement("classes");
+            exercise.appendChild(classes);
+
+            for(String key : k.getClasses(i).keySet()) {
+                Element newClass = dokument.createElement("class");
+                newClass.setAttribute("name", key);
+                newClass.appendChild(dokument.createTextNode(k.getClasses(i).get(key)));
+                classes.appendChild(newClass);
+            }
+
+            Element tests = dokument.createElement("tests");
+            exercise.appendChild(tests);
+
+            for(String key : k.getTests(i).keySet()) {
+                Element newTest = dokument.createElement("test");
+                newTest.setAttribute("name", key);
+                newTest.appendChild(dokument.createTextNode(k.getTests(i).get(key)));
+                tests.appendChild(newTest);
+            }
+
+            TransformerFactory factory = TransformerFactory.newInstance();
+            Transformer transformer = factory.newTransformer();
+            DOMSource quelle = new DOMSource(dokument);
+            StreamResult ziel = new StreamResult(f);
+
+            transformer.transform(quelle, ziel);
+        }
+    }
+}

--- a/src/main/java/de/hhu/propra16/amigos/tdd/xml/SaveProgress.java
+++ b/src/main/java/de/hhu/propra16/amigos/tdd/xml/SaveProgress.java
@@ -52,6 +52,16 @@ public class SaveProgress {
                 tests.appendChild(newTest);
             }
 
+            Element options = dokument.createElement("options");
+            exercise.appendChild(options);
+
+            for(String key : k.getOptions(i).keySet()) {
+                Element newOption = dokument.createElement("option");
+                newOption.setAttribute("name", key);
+                newOption.setAttribute("value", Boolean.toString(k.getOptions(i).get(key)));
+                options.appendChild(newOption);
+            }
+
             TransformerFactory factory = TransformerFactory.newInstance();
             Transformer transformer = factory.newTransformer();
             DOMSource quelle = new DOMSource(dokument);

--- a/src/main/java/de/hhu/propra16/amigos/tdd/xml/SaveProgress.java
+++ b/src/main/java/de/hhu/propra16/amigos/tdd/xml/SaveProgress.java
@@ -58,7 +58,7 @@ public class SaveProgress {
             for(String key : k.getOptions(i).keySet()) {
                 Element newOption = dokument.createElement("option");
                 newOption.setAttribute("name", key);
-                newOption.setAttribute("value", Boolean.toString(k.getOptions(i).get(key)));
+                newOption.setAttribute("value", k.getOptions(i).get(key));
                 options.appendChild(newOption);
             }
 


### PR DESCRIPTION
In tdd ist nun ein Unterordner xml. In diesem können zum einen XML-Files eingelesen werden und ein Katalog wird ausgegeben. Strukturen sind in jeweiligen File zu sehen. In einem Katalog befinden sich mehrere Exercises. 

Fortschritt kann in einer XML-Datei gespeichert werden. Dazu wird ein bearbeiteter Katalog abgespeichert. Dies ist wieder in demselben Format gehalten. Dabei ist die Beispielkonfiguration auf dem Zettel die Konfiguration, die eingelesen wird.

Das zip-File-Handling wird an dieser Stelle möglicherweise unnötig, wenn wir Projekte auch gleich als einzige XML-Datei abgeben lassen könnten.

Das abgespeicherte XML-File ist übrigens nicht eingerückt, aber das kann an dieser Stelle erst einmal egal sein. Die Dateien sollen ja nicht so eingesehen werden, sondern mit dem entwickelten Programm geöffnet werden.
