### PR TITLE
Editor Autoformatierung

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ repositories {
 dependencies {
     compile group: 'de.hhu.stups', name: 'virtual-kata-lib', version: '1.0.0'
     compile group: 'org.fxmisc.richtext', name: 'richtextfx', version: '0.6.10'
+    compile group: 'com.google.googlejavaformat', name: 'google-java-format', version: '1.0'
     testCompile group: 'junit', name: 'junit', version: '4.+'
 }
 

--- a/src/main/java/de/hhu/propra16/amigos/tdd/gui/ChooseExerciseController.java
+++ b/src/main/java/de/hhu/propra16/amigos/tdd/gui/ChooseExerciseController.java
@@ -105,7 +105,9 @@ public class ChooseExerciseController implements Initializable{
             stage.setTitle(selectedExercise.getName() + " | TDD Trainer");
             stage.setMinHeight(600);
             stage.setMinWidth(500);
-            stage.setScene(new Scene(root, 1050, 800));
+            Scene scene = new Scene(root, 1050, 800);
+            stage.setScene(scene);
+            exContr.initializeHotkeys(scene);
             stage.show();
             stage.setMaximized(true);
         }catch(Exception ex){

--- a/src/main/java/de/hhu/propra16/amigos/tdd/gui/ExerciseController.java
+++ b/src/main/java/de/hhu/propra16/amigos/tdd/gui/ExerciseController.java
@@ -1,6 +1,6 @@
 package de.hhu.propra16.amigos.tdd.gui;
 
-import de.hhu.propra16.amigos.tdd.gui.controls.TDDCodeArea;
+import de.hhu.propra16.amigos.tdd.gui.controls.FormattableTDDCodeArea;
 import de.hhu.propra16.amigos.tdd.logik.CodeObject;
 import de.hhu.propra16.amigos.tdd.logik.LogikHandler;
 import de.hhu.propra16.amigos.tdd.logik.TDDState;
@@ -10,13 +10,16 @@ import javafx.animation.*;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
+import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
-import javafx.stage.Stage;
 import javafx.util.Duration;
 import java.io.InputStream;
 import java.util.Timer;
@@ -39,7 +42,7 @@ public class ExerciseController {
     @FXML
     private CheckBox displayCodeTestsBesideCheckbox;
     @FXML
-    private TDDCodeArea codeArea, testArea, atddArea;
+    private FormattableTDDCodeArea codeArea, testArea, atddArea;
     @FXML
     private Tab codeTestTab, testTab, atddTab, outputTab;
     @FXML
@@ -79,6 +82,11 @@ public class ExerciseController {
         ft.setFromValue(0);
         ft.setToValue(1);
         ft.play();
+    }
+
+    public void initializeHotkeys(Scene scene){
+        KeyCodeCombination ctrlSpace = new KeyCodeCombination(KeyCode.SPACE, KeyCombination.CONTROL_ANY);
+        scene.getAccelerators().put(ctrlSpace, this::formatCode);
     }
 
     private void applyStateToGUI(){
@@ -137,6 +145,7 @@ public class ExerciseController {
 
     private void runAndUpdateGUI(boolean switchAlwaysToOutputTab){
         StringBuilder output = new StringBuilder();
+        formatCode();
         this.logikHandler.setCode(this.codeArea.getText());
         this.logikHandler.setTest(this.testArea.getText());
 
@@ -149,6 +158,12 @@ public class ExerciseController {
         if(outputString.equals("")) outputString = "Nothing here, all fine :)";
         compilerArea.setText(outputString);
         doOutputScaleAnimation();
+    }
+
+    private void formatCode() {
+        this.codeArea.formatCode();
+        this.testArea.formatCode();
+        this.atddArea.formatCode();
     }
 
     private void updateGuiForAtdd(StringBuilder output) {

--- a/src/main/java/de/hhu/propra16/amigos/tdd/gui/controls/FormattableTDDCodeArea.java
+++ b/src/main/java/de/hhu/propra16/amigos/tdd/gui/controls/FormattableTDDCodeArea.java
@@ -1,0 +1,36 @@
+package de.hhu.propra16.amigos.tdd.gui.controls;
+
+import com.google.googlejavaformat.java.Formatter;
+import com.google.googlejavaformat.java.JavaFormatterOptions;
+import org.fxmisc.richtext.PlainTextChange;
+
+public class FormattableTDDCodeArea extends TDDCodeArea{
+    private final Formatter formatter;
+    private boolean lastCharAddedWasOpenBracket = false;
+
+    public FormattableTDDCodeArea(){
+        super();
+        JavaFormatterOptions options = new JavaFormatterOptions(JavaFormatterOptions.JavadocFormatter.NONE, JavaFormatterOptions.Style.AOSP, JavaFormatterOptions.SortImports.NO);
+        this.formatter = new Formatter(options);
+        this.plainTextChanges().subscribe(this::bracketInsertListener);
+    }
+
+    public void formatCode(){
+        try{
+            this.setText(formatter.formatSource(this.getText()));
+        }catch(Exception ex){}
+    }
+
+    private void bracketInsertListener(PlainTextChange change){
+        if(this.lastCharAddedWasOpenBracket){
+            this.lastCharAddedWasOpenBracket = false;
+            if(change.getInserted().equals("\n")){
+                this.insertText(change.getPosition(), "\n\n}");
+                this.moveTo(this.getCaretPosition() - 2);
+            }
+        }else{
+            if(change.getInserted().equals("{")) this.lastCharAddedWasOpenBracket = true;
+        }
+    }
+
+}

--- a/src/main/java/de/hhu/propra16/amigos/tdd/gui/editor.fxml
+++ b/src/main/java/de/hhu/propra16/amigos/tdd/gui/editor.fxml
@@ -6,15 +6,14 @@
 <?import javafx.scene.control.TextArea?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.layout.VBox?>
-<?import de.hhu.propra16.amigos.tdd.gui.controls.TDDCodeArea?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.control.TabPane?>
 <?import javafx.scene.control.Tab?>
 <?import javafx.scene.control.CheckBox?>
-
 <?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.layout.HBox?>
+<?import de.hhu.propra16.amigos.tdd.gui.controls.FormattableTDDCodeArea?>
+
 <GridPane fx:controller="de.hhu.propra16.amigos.tdd.gui.ExerciseController"
           xmlns:fx="http://javafx.com/fxml" alignment="TOP_LEFT" hgap="10" vgap="10" styleClass="root" maxWidth="Infinity" maxHeight="Infinity">
     <padding><Insets top="10" bottom="10" left="20" right="20"/></padding>
@@ -85,8 +84,8 @@
                             <ColumnConstraints percentWidth="50" />
                             <ColumnConstraints percentWidth="50" />
                         </columnConstraints>
-                        <TDDCodeArea styleClass="editor" fx:id="codeArea" text="Code" GridPane.columnIndex="0" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS" />
-                        <TDDCodeArea styleClass="editor" fx:id="testArea" text="Test" GridPane.columnIndex="1" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS" />
+                        <FormattableTDDCodeArea styleClass="editor" fx:id="codeArea" text="Code" GridPane.columnIndex="0" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS" />
+                        <FormattableTDDCodeArea styleClass="editor" fx:id="testArea" text="Test" GridPane.columnIndex="1" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS" />
                     </GridPane>
                 </content>
             </Tab>
@@ -96,7 +95,7 @@
             </Tab>
             <Tab text="Acceptance Tests" fx:id="atddTab">
                 <content>
-                    <TDDCodeArea styleClass="editor" fx:id="atddArea" text="class ATDD {&#10;&#10;&#10;}" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS" />
+                    <FormattableTDDCodeArea styleClass="editor" fx:id="atddArea" text="class ATDD {&#10;&#10;&#10;}" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS" />
                 </content>
             </Tab>
             <Tab text="Compile/Test Output" fx:id="outputTab" >


### PR DESCRIPTION
Habe noch Autoformatierung/-einrückung des Codes/der Tests beim Drücken auf Compilen bzw. mit <kbd>CTRL</kbd>+<kbd>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</kbd> eingefügt. Außerdem wird versucht beim Drücken von <kbd>{</kbd> und anschließend <kbd>↵</kbd> die eckige Klammer automatisch zu schließen.

Dies scheint soweit ganz gut zu funktionieren, dennoch wäre ein genauerer Praxistest ganz gut, wenn jemand Zeit haben sollte kann er ja mal versuchen damit testgetrieben zu Entwickeln.
